### PR TITLE
Fix blank input bug

### DIFF
--- a/src/utils/service.js
+++ b/src/utils/service.js
@@ -1,7 +1,9 @@
 const getPhotos = async (query) => {
-    let endpoint = (query === undefined) ? 
-    `https://api.pexels.com/v1/curated?per_page=50`:
-    `https://api.pexels.com/v1/search?query=${query}&per_page=50`;
+    
+    const endpoint = query ? 
+    `https://api.pexels.com/v1/search?query=${query}&per_page=50`:
+    `https://api.pexels.com/v1/curated?per_page=50`;
+    
     try{
         let response = await fetch(endpoint, {
             headers: {


### PR DESCRIPTION
The query ternary statement only checks against `undefined`. But a blank text input in the browser doesn't have a value of undefined- this gets passed a blank string, which breaks the api call. 

With this change, if the query were *any* false-y value `''`/`undefined` etc etc, you'll get that curated query.